### PR TITLE
Replaced CAPNSOpenSSL with CNIOBoringSSL

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -14,18 +14,9 @@ let package = Package(
         .package(url: "https://github.com/apple/swift-nio-http2.git", from: "1.0.0"),
     ],
     targets: [
-        .systemLibrary(
-            name: "CAPNSOpenSSL",
-            pkgConfig: "openssl",
-            providers: [
-                .apt(["openssl libssl-dev"]),
-                .brew(["openssl"]),
-            ]
-        ),
-
         .target(name: "NIOAPNSExample", dependencies: ["NIOAPNS"]),
 
-        .target(name: "NIOAPNSJWT", dependencies:["CAPNSOpenSSL"]),
+        .target(name: "NIOAPNSJWT", dependencies:["NIOSSL"]),
 
         .testTarget(name: "NIOAPNSJWTTests", dependencies: ["NIOAPNSJWT"]),
 

--- a/Sources/NIOAPNSJWT/DataSigner.swift
+++ b/Sources/NIOAPNSJWT/DataSigner.swift
@@ -5,22 +5,22 @@
 //  Created by Kyle Browning on 2/21/19.
 //
 import Foundation
-import CAPNSOpenSSL
+import CNIOBoringSSL
 
 public class DataSigner: APNSSigner {
     private let opaqueKey: OpaquePointer
 
     public init(data: Data) throws {
-        let bio = BIO_new(BIO_s_mem())
-        defer { BIO_free(bio) }
+        let bio = CNIOBoringSSL_BIO_new(CNIOBoringSSL_BIO_s_mem())
+        defer { CNIOBoringSSL_BIO_free(bio) }
 
         let nullTerminatedData = data + Data([0])
         let res = nullTerminatedData.withUnsafeBytes { ptr in
-            return BIO_puts(bio, ptr.baseAddress?.assumingMemoryBound(to: Int8.self))
+            return CNIOBoringSSL_BIO_puts(bio, ptr.baseAddress?.assumingMemoryBound(to: Int8.self))
         }
         assert(res >= 0, "BIO_puts failed")
 
-        if let pointer  = PEM_read_bio_ECPrivateKey(bio!, nil, nil, nil) {
+        if let pointer  = CNIOBoringSSL_PEM_read_bio_ECPrivateKey(bio!, nil, nil, nil) {
             self.opaqueKey = pointer
         } else {
             throw APNSSignatureError.invalidAuthKey
@@ -28,17 +28,17 @@ public class DataSigner: APNSSigner {
     }
 
     deinit {
-        EC_KEY_free(opaqueKey)
+        CNIOBoringSSL_EC_KEY_free(opaqueKey)
     }
 
     public func sign(digest: Data) throws -> Data  {
-        let sig = digest.withUnsafeBytes { ptr in
-            return ECDSA_do_sign(ptr.baseAddress?.assumingMemoryBound(to: UInt8.self), Int32(digest.count), opaqueKey)
+        let sig = digest.withUnsafeBytes {
+            return CNIOBoringSSL_ECDSA_do_sign($0.baseAddress?.assumingMemoryBound(to: UInt8.self), digest.count, opaqueKey)
         }
-        defer { ECDSA_SIG_free(sig) }
+        defer { CNIOBoringSSL_ECDSA_SIG_free(sig) }
 
         var derEncodedSignature: UnsafeMutablePointer<UInt8>? = nil
-        let derLength = i2d_ECDSA_SIG(sig, &derEncodedSignature)
+        let derLength = CNIOBoringSSL_i2d_ECDSA_SIG(sig, &derEncodedSignature)
         
         guard let derCopy = derEncodedSignature, derLength > 0 else {
             throw APNSSignatureError.invalidASN1

--- a/Sources/NIOAPNSJWT/FileSigner.swift
+++ b/Sources/NIOAPNSJWT/FileSigner.swift
@@ -6,7 +6,7 @@
 //
 
 import Foundation
-import CAPNSOpenSSL
+import CNIOBoringSSL
 public class FileSigner: DataSigner {
     public convenience init(url: URL) throws {
         do {

--- a/Sources/NIOAPNSJWT/SHA256.swift
+++ b/Sources/NIOAPNSJWT/SHA256.swift
@@ -6,20 +6,20 @@
 //
 
 import Foundation
-import CAPNSOpenSSL
+import CNIOBoringSSL
 
 func sha256(message: Data) -> Data {
     var context = SHA256_CTX()
-    SHA256_Init(&context)
+    CNIOBoringSSL_SHA256_Init(&context)
 
     var res = message.withUnsafeBytes { buffer in
-        return SHA256_Update(&context, buffer.baseAddress, buffer.count)
+        return CNIOBoringSSL_SHA256_Update(&context, buffer.baseAddress, buffer.count)
     }
     assert(res == 1, "SHA256_Update failed")
 
     var digest = Data(count: Int(SHA256_DIGEST_LENGTH))
     res = digest.withUnsafeMutableBytes { mptr in
-        return SHA256_Final(mptr.baseAddress?.assumingMemoryBound(to: UInt8.self), &context)
+        return CNIOBoringSSL_SHA256_Final(mptr.baseAddress?.assumingMemoryBound(to: UInt8.self), &context)
     }
     assert(res == 1, "SHA256_Final failed")
 


### PR DESCRIPTION
I think it's better to reuse CNIOBoringSSL from NIOSSL 😉

Tested on macOS 10.14.4 and ubuntu server 16.04