### PR TITLE
Fixed bug

### DIFF
--- a/Sources/NIOAPNS/APNSConnection.swift
+++ b/Sources/NIOAPNS/APNSConnection.swift
@@ -80,10 +80,12 @@ public final class APNSConnection {
             request: buffer,
             responsePromise: responsePromise
         )
+
         return streamPromise.futureResult.flatMap { stream in
-            stream.writeAndFlush(context)
-        }.flatMap {
-            responsePromise.futureResult
+            responsePromise.futureResult.whenComplete { _ in }
+            return stream.writeAndFlush(context)
+            }.flatMap {
+                responsePromise.futureResult
         }
     }
 


### PR DESCRIPTION
When the connection fails, responsePromise get's deallocated (deinit is called) without being fulfilled.
This causes a fatal error in debug: "fatalError("leaking promise created at \(creation)", file: creation.file, line: creation.line)", file EventLoopFuture.swift.
The case is that when flatMap fails, there's no path in which the promise get's fulfilled.
This solution fulfills the promise, even if nothing is done with it.

Setup to reproduce:

macOS 1.14.5
Xcode 10.2.1
Swift 5.0.1

Implemented a test website to send push notifications to my phone. There's some other issue that causes an invalidAuthKey error about 50% of the time, which is probably my fault, but it's not the subject of this pull request.

When the error happens, most of the time (sometimes immediately, it's very easy to reproduce) the error described above happens.

I believe there should be a better solution that involves a review of the logic, but as this is my first Digg into the code, I don't feel ready for that, so I hope that you guys review it and tell me if this is a proper solution or there's a cleaner one.

Whatever the case, this fixes the crash (in debug), so I'm going to use it in my own work with my fork.

Please let me know if I can improve this PR as I'm not often participate in open source projects so the etiquette could be off.
Thanks.
Eduardo